### PR TITLE
Sync with original template to fix CI publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,15 +4,8 @@ on:
   # Runs on pushes targeting the default branch
   push:
     branches: ["main"]
-
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
-
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
-permissions:
-  contents: read
-  pages: write
-  id-token: write
 
 # Allow one concurrent deployment
 concurrency:
@@ -25,15 +18,16 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        shell: bash -l {0}
+        shell: bash -el {0}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Install Conda environment with Micromamba
-        uses: mamba-org/provision-with-micromamba@v16
+        uses: mamba-org/setup-micromamba@v2
         with:
-          cache-env: true
+          environment-file: environment.yml
+          cache-environment: true
 
       - name: Build the Book
         run: jb build book
@@ -49,6 +43,12 @@ jobs:
     needs: build
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+
+    # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+    permissions:
+      pages: write
+      id-token: write
+  
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: geosmart-template
 channels:
   - conda-forge
 dependencies:
-  - python=3
+  - python=3.12
   - sphinxcontrib-bibtex
   - jupyter-book
   - jupytext


### PR DESCRIPTION
CI is currently broken because this step is deprecated https://github.com/mamba-org/provision-with-micromamba?tab=readme-ov-file

So, this PR syncs back up with the original template used for starting this repository (https://github.com/geo-smart/simple-template)

Specifically: 

- Use https://github.com/mamba-org/setup-micromamba 
- Pin Python 3.12